### PR TITLE
fix: correct cd path for manual download

### DIFF
--- a/web-no-modal-sdk/evm/nextjs-evm-no-modal-example/README.md
+++ b/web-no-modal-sdk/evm/nextjs-evm-no-modal-example/README.md
@@ -18,11 +18,11 @@ npx degit Web3Auth/web3auth-pnp-examples/web-modal-sdk/evm/nextjs-evm-no-modal-e
 Install & Run:
 
 ```bash
-cd w3a-modal-evm-nextjs
+cd w3a-no-modal-evm-nextjs
 npm install
 npm run dev
 # or
-cd w3a-modal-evm-nextjs
+cd w3a-no-modal-evm-nextjs
 yarn
 yarn dev
 ```


### PR DESCRIPTION
change the path for the cd command to match the directory name specified in the manual download command